### PR TITLE
git clone

### DIFF
--- a/git clone
+++ b/git clone
@@ -1,0 +1,1 @@
+git clone https://github.com/actions/python-versions/releases/download/3.8.18-12303122501/python-3.8.18-linux-24.04-x64.tar.gz


### PR DESCRIPTION
`git clone https://github.com/actions/python-versions/releases/download/3.8.18-12303122501/python-3.8.18-linux-24.04-x64.tar.gz`